### PR TITLE
Remove default credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ A Firefox extension for managing 922proxy service connections through FoxyProxy.
 ## Usage
 
 1. Click the extension icon to open the popup
-2. Enter your 922proxy credentials
+2. Enter your 922proxy credentials. The extension no longer ships with
+   built-in credentials, so you must supply your own username and password.
 3. Click "Generate New Proxies" to create proxy configurations
 4. Download the configuration file
 5. Import the configuration into FoxyProxy

--- a/background.js
+++ b/background.js
@@ -37,9 +37,9 @@ class ProxyManager {
                 this.config = result.proxyConfig;
             } else {
                 this.config = {
-                    username: '85644296-zone-custom',
-                    password: '9VTOEdg9',
-                    endpoint: 'na.proxys5.net', 
+                    username: '', // user-supplied
+                    password: '', // user-supplied
+                    endpoint: 'na.proxys5.net',
                     port: 6200,
                     region: 'US',
                     proxyCount: 10

--- a/foxyproxy-generator.js
+++ b/foxyproxy-generator.js
@@ -11,10 +11,11 @@ class FoxyProxyGenerator {
       proxyCount: 10              // Default number of proxies
     }, config);
     
-    // Credentials object (only username/password)
+    // Credentials object (only username/password). Values should be provided
+    // by the user through the extension UI.
     this.credentials = {
-      username: '85644296-zone-custom', // Default placeholder, will be overridden
-      password: ''                      // Will be set from credentials form
+      username: '',
+      password: ''
     };
 
     // Predefined colors for proxies
@@ -62,9 +63,9 @@ class FoxyProxyGenerator {
     const colorIndex = index % this.colors.length;
     const iconIndex = index % this.icons.length;
     
-    // Get credentials (simplified to just username/password)
-    let username = this.credentials.username || '85644296-zone-custom';
-    let password = this.credentials.password || '9VTOEdg9';
+    // Get credentials provided by the user
+    let username = this.credentials.username;
+    let password = this.credentials.password;
     
     // Ensure correct username format with session ID for uniqueness
     const authUsername = `${username}-region-${this.config.region}-sessid-${sessionId}-sessTime-15`;


### PR DESCRIPTION
## Summary
- avoid storing 922proxy username/password in the repository
- rely on user supplied credentials only
- clarify requirement for providing credentials in README

## Testing
- `git status --short`

## Summary by Sourcery

Remove embedded default credentials from both generator and background scripts, enforce user-supplied authentication data, and update documentation to reflect this change.

Enhancements:
- Remove hardcoded default proxy credentials and initialize username/password fields empty
- Require users to supply their own 922proxy credentials via the extension UI
- Remove fallback to built-in credential values when generating proxy configurations

Documentation:
- Clarify in README that the extension no longer includes built-in credentials and requires user-provided username and password